### PR TITLE
Feat/less annoying resolution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openmw-config"
 description = "A library for interacting with the Openmw Configuration system."
-version = "1.0.5"
+version = "1.1.0"
 authors = ["Dave Corley (S3kshun8) <corleycomputerrepair@protonmail.ch>"]
 license = "GPL-3.0-or-later"
 repository = "https://github.com/DreamWeave-MP/Openmw_Config"

--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ Module exports (`openmwConfig`):
 | `defaultLocalPath()` | `string` | Path backing the `?local?` token |
 | `defaultGlobalPath()` | `string` | Path backing the `?global?` token (throws on unsupported platforms) |
 | `tryDefaultConfigPath()` | `(string|nil, string|nil)` | Tuple-style success/error |
-| `tryDefaultUserConfigFile()` | `(string|nil, string|nil)` | Tuple-style success/error |
-| `tryDefaultRootOrUserConfigPath()` | `(string|nil, string|nil)` | Tuple-style success/error |
+| `tryDefaultUserConfigFile()` | `(string\|nil, string\|nil)` | Tuple-style success/error |
+| `tryDefaultRootOrUserConfigPath()` | `(string\|nil, string\|nil)` | Tuple-style success/error |
 | `tryDefaultUserDataPath()` | `(string|nil, string|nil)` | Tuple-style success/error |
 | `tryDefaultLocalPath()` | `(string|nil, string|nil)` | Tuple-style success/error |
 | `tryDefaultGlobalPath()` | `(string|nil, string|nil)` | Tuple-style success/error |

--- a/README.md
+++ b/README.md
@@ -163,6 +163,20 @@ entry such as `config="?userconfig?"`. Starting directly from the user config sk
 baseline. That is not equivalent, even if it looks fine on the machine that wrote the bug. Ask how
 we know.
 
+External tools that should prefer OpenMW startup semantics but still work on installs with only a
+user config should use `OpenMWConfiguration::from_env_or_user_config()`:
+
+```rust,no_run
+use openmw_config::OpenMWConfiguration;
+
+let config = OpenMWConfiguration::from_env_or_user_config()?;
+# Ok::<(), openmw_config::ConfigError>(())
+```
+
+This first honors `from_env()` behavior. If no executable-adjacent or global root `openmw.cfg` is
+found, it falls back to the default user config (`?userconfig?/openmw.cfg`). Explicit bad paths are
+still errors; the fallback is not a shovel for burying mistakes.
+
 ### Modifying and saving
 
 ```rust,no_run
@@ -303,15 +317,19 @@ Module exports (`openmwConfig`):
 | Lua function | Returns | Notes |
 |---|---|---|
 | `fromEnv()` | `config` userdata | Loads using `OPENMW_CONFIG` / `OPENMW_CONFIG_DIR` semantics |
+| `fromEnvOrUserConfig()` | `config` userdata | `fromEnv()` plus default user-config fallback when no root config exists |
 | `new(pathOrNil)` | `config` userdata | `pathOrNil` may be file path, dir path, or `nil` |
 | `newEmpty(userConfigDir)` | `config` userdata | Starts empty from a config directory without reading disk |
 | `loadOptional(path)` | `config` userdata | Loads if present; missing paths start empty with matching config context |
 | `defaultConfigPath()` | `string` | Platform default config dir |
+| `defaultUserConfigFile()` | `string` | Platform default user `openmw.cfg` file |
 | `defaultUserDataPath()` | `string` | Platform default userdata dir |
 | `defaultDataLocalPath()` | `string` | Platform default data-local dir |
 | `defaultLocalPath()` | `string` | Path backing the `?local?` token |
 | `defaultGlobalPath()` | `string` | Path backing the `?global?` token (throws on unsupported platforms) |
 | `tryDefaultConfigPath()` | `(string|nil, string|nil)` | Tuple-style success/error |
+| `tryDefaultUserConfigFile()` | `(string|nil, string|nil)` | Tuple-style success/error |
+| `tryDefaultRootOrUserConfigPath()` | `(string|nil, string|nil)` | Tuple-style success/error |
 | `tryDefaultUserDataPath()` | `(string|nil, string|nil)` | Tuple-style success/error |
 | `tryDefaultLocalPath()` | `(string|nil, string|nil)` | Tuple-style success/error |
 | `tryDefaultGlobalPath()` | `(string|nil, string|nil)` | Tuple-style success/error |

--- a/src/config.rs
+++ b/src/config.rs
@@ -1726,6 +1726,17 @@ mod tests {
         }
     }
 
+    fn restore_env_var(key: &str, value: Option<std::ffi::OsString>) {
+        // SAFETY: callers hold env_lock(). Environment mutation is process-global.
+        unsafe {
+            if let Some(value) = value {
+                std::env::set_var(key, value);
+            } else {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
     fn load(cfg_contents: &str) -> OpenMWConfiguration {
         let dir = temp_dir();
         write_cfg(&dir, cfg_contents);
@@ -2834,23 +2845,30 @@ mod tests {
     fn test_from_env_or_user_config_falls_back_to_user_config() {
         let _guard = env_lock();
         let empty_global_dir = temp_dir();
-        let xdg_config_home = temp_dir();
-        let user_config_dir = xdg_config_home.join("openmw");
-        std::fs::create_dir_all(&user_config_dir).unwrap();
-        let user_cfg = write_cfg(&user_config_dir, "content=UserOnly.esm\n");
+        let test_home = temp_dir();
+        let test_xdg_config_home = temp_dir();
+        let old_home = std::env::var_os("HOME");
+        let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
 
         unsafe {
             clear_from_env_overrides();
             std::env::set_var("OPENMW_GLOBAL_CONFIG_PATH", &empty_global_dir);
-            std::env::set_var("XDG_CONFIG_HOME", &xdg_config_home);
+            std::env::set_var("HOME", &test_home);
+            std::env::set_var("XDG_CONFIG_HOME", &test_xdg_config_home);
         }
 
-        let config = OpenMWConfiguration::from_env_or_user_config().unwrap();
+        let user_config_dir = crate::try_default_config_path().unwrap();
+        std::fs::create_dir_all(&user_config_dir).unwrap();
+        let user_cfg = write_cfg(&user_config_dir, "content=UserOnly.esm\n");
+
+        let result = OpenMWConfiguration::from_env_or_user_config();
         unsafe {
             clear_from_env_overrides();
-            std::env::remove_var("XDG_CONFIG_HOME");
         }
+        restore_env_var("HOME", old_home);
+        restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
 
+        let config = result.unwrap();
         assert_eq!(config.root_config_file(), user_cfg);
         assert!(config.has_content_file("UserOnly.esm"));
     }
@@ -2860,19 +2878,24 @@ mod tests {
     fn test_from_env_or_user_config_errors_when_no_candidates_exist() {
         let _guard = env_lock();
         let empty_global_dir = temp_dir();
-        let xdg_config_home = temp_dir();
+        let test_home = temp_dir();
+        let test_xdg_config_home = temp_dir();
+        let old_home = std::env::var_os("HOME");
+        let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
 
         unsafe {
             clear_from_env_overrides();
             std::env::set_var("OPENMW_GLOBAL_CONFIG_PATH", &empty_global_dir);
-            std::env::set_var("XDG_CONFIG_HOME", &xdg_config_home);
+            std::env::set_var("HOME", &test_home);
+            std::env::set_var("XDG_CONFIG_HOME", &test_xdg_config_home);
         }
 
         let result = OpenMWConfiguration::from_env_or_user_config();
         unsafe {
             clear_from_env_overrides();
-            std::env::remove_var("XDG_CONFIG_HOME");
         }
+        restore_env_var("HOME", old_home);
+        restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
 
         assert!(
             matches!(result, Err(ConfigError::CannotFindAnyConfig { .. })),

--- a/src/config.rs
+++ b/src/config.rs
@@ -325,7 +325,7 @@ impl OpenMWConfiguration {
             } else if explicit_path.is_absolute() {
                 return Self::new(Some(explicit_path));
             } else if explicit_path.is_relative() {
-                return Self::new(Some(std::fs::canonicalize(explicit_path)?));
+                return Self::new(Some(util::display_preserving_absolute(&explicit_path)?));
             }
             return Err(ConfigError::NotFileOrDirectory(explicit_path));
         } else if let Ok(path_list) = std::env::var("OPENMW_CONFIG_DIR") {
@@ -444,7 +444,7 @@ impl OpenMWConfiguration {
         }
 
         if user_config_dir.is_relative() {
-            user_config_dir = std::env::current_dir()?.join(user_config_dir);
+            user_config_dir = util::display_preserving_absolute(&user_config_dir)?;
         }
 
         Ok(Self {
@@ -521,14 +521,14 @@ impl OpenMWConfiguration {
 
     #[must_use]
     pub fn is_user_config(&self) -> bool {
-        self.root_config_dir() == self.user_config_path()
+        util::paths_equivalent(&self.root_config_dir(), &self.user_config_path())
     }
 
     /// # Errors
     /// Returns [`ConfigError`] if the user config path cannot be loaded.
     pub fn user_config(self) -> Result<Self, ConfigError> {
         let user_path = self.user_config_path();
-        if self.root_config_dir() == user_path {
+        if util::paths_equivalent(&self.root_config_dir(), &user_path) {
             Ok(self)
         } else {
             Self::new(Some(user_path))
@@ -539,7 +539,7 @@ impl OpenMWConfiguration {
     /// Returns [`ConfigError`] if the user config path cannot be loaded.
     pub fn user_config_ref(&self) -> Result<Self, ConfigError> {
         let user_path = self.user_config_path();
-        if self.root_config_dir() == user_path {
+        if util::paths_equivalent(&self.root_config_dir(), &user_path) {
             Ok(self.clone())
         } else {
             Self::new(Some(user_path))
@@ -1557,9 +1557,9 @@ impl OpenMWConfiguration {
 
         let mut user_settings_string = String::new();
 
-        for user_setting in
-            self.settings_matching(|setting| setting.meta().source_config == cfg_path)
-        {
+        for user_setting in self.settings_matching(|setting| {
+            util::paths_equivalent(&setting.meta().source_config, &cfg_path)
+        }) {
             if self.is_synthetic_data_local_data_directory(user_setting) {
                 continue;
             }
@@ -1584,7 +1584,7 @@ impl OpenMWConfiguration {
     pub fn save_subconfig(&self, target_dir: &Path) -> Result<(), ConfigError> {
         let subconfig_is_loaded = self.settings.iter().any(|setting| match setting {
             SettingValue::SubConfiguration(subconfig) => {
-                subconfig.parsed() == target_dir
+                util::paths_equivalent(subconfig.parsed(), target_dir)
                     || subconfig.original() == target_dir.to_string_lossy().as_ref()
             }
             _ => false,
@@ -1602,9 +1602,9 @@ impl OpenMWConfiguration {
 
         let mut subconfig_settings_string = String::new();
 
-        for subconfig_setting in
-            self.settings_matching(|setting| setting.meta().source_config == cfg_path)
-        {
+        for subconfig_setting in self.settings_matching(|setting| {
+            util::paths_equivalent(&setting.meta().source_config, &cfg_path)
+        }) {
             if self.is_synthetic_data_local_data_directory(subconfig_setting) {
                 continue;
             }
@@ -2371,6 +2371,33 @@ mod tests {
         );
     }
 
+    #[test]
+    #[cfg(unix)]
+    fn test_save_subconfig_accepts_equivalent_symlink_path() {
+        let root_dir = temp_dir();
+        let real_sub_dir = temp_dir();
+        let linked_sub_dir = temp_dir().join("linked_subconfig");
+
+        std::os::unix::fs::symlink(&real_sub_dir, &linked_sub_dir).unwrap();
+        write_cfg(&real_sub_dir, "content=Plugin.esp\n");
+        write_cfg(
+            &root_dir,
+            &format!(
+                "content=Morrowind.esm\nconfig={}\n",
+                linked_sub_dir.display()
+            ),
+        );
+
+        let config = OpenMWConfiguration::new(Some(root_dir)).unwrap();
+        config.save_subconfig(&real_sub_dir).unwrap();
+
+        let saved = std::fs::read_to_string(real_sub_dir.join("openmw.cfg")).unwrap();
+        assert!(
+            saved.contains("content=Plugin.esp"),
+            "sub-config settings should match by filesystem identity, not symlink spelling"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Empty and optional construction
     // -----------------------------------------------------------------------
@@ -2495,7 +2522,7 @@ mod tests {
             "openmw-config-relative-empty-{}",
             std::process::id()
         ));
-        let expected_dir = std::env::current_dir().unwrap().join(&relative_dir);
+        let expected_dir = util::display_preserving_absolute(&relative_dir).unwrap();
 
         let mut config = OpenMWConfiguration::new_empty(&relative_dir).unwrap();
         config.add_data_directory(Path::new("Data Files"));
@@ -2513,9 +2540,8 @@ mod tests {
             "openmw-config-relative-missing-{}/openmw.cfg",
             std::process::id()
         ));
-        let expected_dir = std::env::current_dir()
-            .unwrap()
-            .join(relative_cfg.parent().unwrap());
+        let expected_dir =
+            util::display_preserving_absolute(relative_cfg.parent().unwrap()).unwrap();
 
         let mut config = OpenMWConfiguration::load_optional(&relative_cfg).unwrap();
         config.add_data_directory(Path::new("Data Files"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -349,6 +349,40 @@ impl OpenMWConfiguration {
         Self::new(Some(root_config))
     }
 
+    /// Loads an `OpenMW` configuration using environment/root discovery with a user-config fallback.
+    ///
+    /// This is the discovery mode external tools normally want:
+    ///
+    /// 1. Honor [`Self::from_env`] semantics, including `OPENMW_CONFIG`, `OPENMW_CONFIG_DIR`,
+    ///    executable-adjacent root config, and platform global root config.
+    /// 2. If strict root discovery finds no root config, fall back to the default user
+    ///    `openmw.cfg` (`?userconfig?/openmw.cfg`).
+    ///
+    /// Explicit environment errors are still errors. This method only adds a fallback for the
+    /// "no local/global root config exists" case.
+    ///
+    /// # Errors
+    /// Returns [`ConfigError`] if config loading fails or if no root/user config exists.
+    pub fn from_env_or_user_config() -> Result<Self, ConfigError> {
+        match Self::from_env() {
+            Ok(config) => Ok(config),
+            Err(ConfigError::CannotFindRootConfig { local, global }) => {
+                let user = crate::try_default_user_config_file()?;
+
+                if user.is_file() {
+                    Self::new(Some(user))
+                } else {
+                    Err(ConfigError::CannotFindAnyConfig {
+                        local,
+                        global,
+                        user,
+                    })
+                }
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     /// # Errors
     /// Returns [`ConfigError`] if the path does not exist, is not a valid config, or if loading the config chain fails.
     ///
@@ -1686,6 +1720,9 @@ mod tests {
             std::env::remove_var("OPENMW_CONFIG");
             std::env::remove_var("OPENMW_CONFIG_DIR");
             std::env::remove_var("OPENMW_GLOBAL_CONFIG_PATH");
+            std::env::remove_var("OPENMW_CONFIG_USING_FLATPAK");
+            std::env::remove_var("OPENMW_FLATPAK_ID");
+            std::env::remove_var("FLATPAK_ID");
         }
     }
 
@@ -2789,6 +2826,57 @@ mod tests {
         assert!(
             matches!(result, Err(ConfigError::CannotFindRootConfig { .. })),
             "expected CannotFindRootConfig, got {result:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_from_env_or_user_config_falls_back_to_user_config() {
+        let _guard = env_lock();
+        let empty_global_dir = temp_dir();
+        let xdg_config_home = temp_dir();
+        let user_config_dir = xdg_config_home.join("openmw");
+        std::fs::create_dir_all(&user_config_dir).unwrap();
+        let user_cfg = write_cfg(&user_config_dir, "content=UserOnly.esm\n");
+
+        unsafe {
+            clear_from_env_overrides();
+            std::env::set_var("OPENMW_GLOBAL_CONFIG_PATH", &empty_global_dir);
+            std::env::set_var("XDG_CONFIG_HOME", &xdg_config_home);
+        }
+
+        let config = OpenMWConfiguration::from_env_or_user_config().unwrap();
+        unsafe {
+            clear_from_env_overrides();
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+
+        assert_eq!(config.root_config_file(), user_cfg);
+        assert!(config.has_content_file("UserOnly.esm"));
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_from_env_or_user_config_errors_when_no_candidates_exist() {
+        let _guard = env_lock();
+        let empty_global_dir = temp_dir();
+        let xdg_config_home = temp_dir();
+
+        unsafe {
+            clear_from_env_overrides();
+            std::env::set_var("OPENMW_GLOBAL_CONFIG_PATH", &empty_global_dir);
+            std::env::set_var("XDG_CONFIG_HOME", &xdg_config_home);
+        }
+
+        let result = OpenMWConfiguration::from_env_or_user_config();
+        unsafe {
+            clear_from_env_overrides();
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+
+        assert!(
+            matches!(result, Err(ConfigError::CannotFindAnyConfig { .. })),
+            "expected CannotFindAnyConfig, got {result:?}"
         );
     }
 

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -219,6 +219,12 @@ pub enum ConfigError {
     CannotFind(PathBuf),
     /// Root config discovery tried both local and global config candidates and found neither.
     CannotFindRootConfig { local: PathBuf, global: PathBuf },
+    /// External-tool config discovery found neither root nor user config candidates.
+    CannotFindAnyConfig {
+        local: PathBuf,
+        global: PathBuf,
+        user: PathBuf,
+    },
     /// The target path for a save operation is not writable.
     NotWritable(PathBuf),
     /// [`OpenMWConfiguration::save_subconfig`](crate::OpenMWConfiguration::save_subconfig)
@@ -250,8 +256,65 @@ fn cannot_find_root_message(local: &Path, global: &Path) -> String {
     )
 }
 
+fn cannot_find_any_message(local: &Path, global: &Path, user: &Path) -> String {
+    format!(
+        "OpenMW config discovery found no openmw.cfg at local path {}, global config path {}, or user config path {}",
+        local.display(),
+        global.display(),
+        user.display()
+    )
+}
+
+fn fmt_duplicate_or_add_error(
+    error: &ConfigError,
+    f: &mut fmt::Formatter<'_>,
+) -> Option<fmt::Result> {
+    match error {
+        ConfigError::DuplicateContentFile {
+            file,
+            config_path,
+            line,
+        } => Some(f.write_str(&duplicate_message(
+            file,
+            "content files",
+            config_path,
+            *line,
+        ))),
+        ConfigError::CannotAddContentFile { file, config_path } => Some(write!(
+            f,
+            "{file} cannot be added to the configuration map as a content file because it was already defined by: {}",
+            config_path.display()
+        )),
+        ConfigError::DuplicateGroundcoverFile {
+            file,
+            config_path,
+            line,
+        } => Some(f.write_str(&duplicate_message(file, "groundcover", config_path, *line))),
+        ConfigError::CannotAddGroundcoverFile { file, config_path } => Some(write!(
+            f,
+            "{file} cannot be added to the configuration map as a groundcover plugin because it was already defined by: {}",
+            config_path.display()
+        )),
+        ConfigError::DuplicateArchiveFile {
+            file,
+            config_path,
+            line,
+        } => Some(f.write_str(&duplicate_message(file, "BSA/Archive", config_path, *line))),
+        ConfigError::CannotAddArchiveFile { file, config_path } => Some(write!(
+            f,
+            "{file} cannot be added to the configuration map as a fallback-archive because it was already defined by: {}",
+            config_path.display()
+        )),
+        _ => None,
+    }
+}
+
 impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(result) = fmt_duplicate_or_add_error(self, f) {
+            return result;
+        }
+
         match self {
             ConfigError::InvalidGameSetting {
                 value,
@@ -278,41 +341,19 @@ impl fmt::Display for ConfigError {
             ConfigError::CannotFindRootConfig { local, global } => {
                 write!(f, "{}", cannot_find_root_message(local, global))
             }
-            ConfigError::DuplicateContentFile {
-                file,
-                config_path,
-                line,
-            } => f.write_str(&duplicate_message(
-                file,
-                "content files",
-                config_path,
-                *line,
-            )),
-            ConfigError::CannotAddContentFile { file, config_path } => write!(
-                f,
-                "{file} cannot be added to the configuration map as a content file because it was already defined by: {}",
-                config_path.display()
-            ),
-            ConfigError::DuplicateGroundcoverFile {
-                file,
-                config_path,
-                line,
-            } => f.write_str(&duplicate_message(file, "groundcover", config_path, *line)),
-            ConfigError::CannotAddGroundcoverFile { file, config_path } => write!(
-                f,
-                "{file} cannot be added to the configuration map as a groundcover plugin because it was already defined by: {}",
-                config_path.display()
-            ),
-            ConfigError::DuplicateArchiveFile {
-                file,
-                config_path,
-                line,
-            } => f.write_str(&duplicate_message(file, "BSA/Archive", config_path, *line)),
-            ConfigError::CannotAddArchiveFile { file, config_path } => write!(
-                f,
-                "{file} cannot be added to the configuration map as a fallback-archive because it was already defined by: {}",
-                config_path.display()
-            ),
+            ConfigError::CannotFindAnyConfig {
+                local,
+                global,
+                user,
+            } => write!(f, "{}", cannot_find_any_message(local, global, user)),
+            ConfigError::DuplicateContentFile { .. }
+            | ConfigError::CannotAddContentFile { .. }
+            | ConfigError::DuplicateGroundcoverFile { .. }
+            | ConfigError::CannotAddGroundcoverFile { .. }
+            | ConfigError::DuplicateArchiveFile { .. }
+            | ConfigError::CannotAddArchiveFile { .. } => {
+                unreachable!("duplicate/add errors are handled before the main display match")
+            }
             ConfigError::BadEncoding {
                 value,
                 config_path,
@@ -379,6 +420,16 @@ mod tests {
         .to_string();
         assert!(cannot_find_root.contains("/tmp/local/openmw.cfg"));
         assert!(cannot_find_root.contains("/tmp/global/openmw.cfg"));
+
+        let cannot_find_any = ConfigError::CannotFindAnyConfig {
+            local: PathBuf::from("/tmp/local/openmw.cfg"),
+            global: PathBuf::from("/tmp/global/openmw.cfg"),
+            user: PathBuf::from("/tmp/user/openmw.cfg"),
+        }
+        .to_string();
+        assert!(cannot_find_any.contains("/tmp/local/openmw.cfg"));
+        assert!(cannot_find_any.contains("/tmp/global/openmw.cfg"));
+        assert!(cannot_find_any.contains("/tmp/user/openmw.cfg"));
 
         let duplicate = ConfigError::DuplicateContentFile {
             file: "Morrowind.esm".into(),

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2025 Dave Corley (S3kshun8)
 
+use std::path::{Path, PathBuf};
+
 #[must_use]
 pub fn debug_enabled() -> bool {
     std::env::var("CFG_DEBUG").is_ok()
@@ -57,16 +59,57 @@ pub fn is_writable(path: &std::path::Path) -> bool {
     }
 }
 
-pub fn validate_path(
-    check_path: std::path::PathBuf,
-) -> Result<std::path::PathBuf, crate::ConfigError> {
+pub(crate) fn canonical_path_if_exists(path: &Path) -> Option<PathBuf> {
+    std::fs::canonicalize(path).ok()
+}
+
+pub(crate) fn paths_equivalent(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+
+    match (
+        canonical_path_if_exists(left),
+        canonical_path_if_exists(right),
+    ) {
+        (Some(left), Some(right)) => left == right,
+        _ => false,
+    }
+}
+
+fn display_preserving_current_dir() -> Result<PathBuf, crate::ConfigError> {
+    let real_current_dir = std::env::current_dir()?;
+
+    let Some(pwd) = std::env::var_os("PWD")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+    else {
+        return Ok(real_current_dir);
+    };
+
+    match std::fs::canonicalize(&pwd) {
+        Ok(canonical_pwd) if canonical_pwd == real_current_dir => Ok(pwd),
+        _ => Ok(real_current_dir),
+    }
+}
+
+pub(crate) fn display_preserving_absolute(path: &Path) -> Result<PathBuf, crate::ConfigError> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+
+    display_preserving_current_dir().map(|current_dir| current_dir.join(path))
+}
+
+pub fn validate_path(check_path: PathBuf) -> Result<PathBuf, crate::ConfigError> {
     if check_path.as_os_str().is_empty() {
         Err(crate::ConfigError::NotFileOrDirectory(check_path))
     } else if check_path.is_absolute() {
         Ok(check_path)
     } else if check_path.is_relative() {
         if check_path.exists() {
-            Ok(std::fs::canonicalize(check_path)?)
+            display_preserving_absolute(&check_path)
         } else {
             Err(crate::ConfigError::NotFileOrDirectory(check_path))
         }
@@ -77,9 +120,7 @@ pub fn validate_path(
 
 /// Transposes an input directory or file path to an openmw.cfg path
 /// Maybe could do with some additional validation
-pub fn input_config_path(
-    config_path: std::path::PathBuf,
-) -> Result<std::path::PathBuf, crate::ConfigError> {
+pub fn input_config_path(config_path: PathBuf) -> Result<PathBuf, crate::ConfigError> {
     let check_path = validate_path(config_path)?;
 
     match std::fs::metadata(&check_path) {
@@ -109,7 +150,19 @@ pub fn input_config_path(
 
 #[cfg(test)]
 mod tests {
-    use super::expand_leading_tilde;
+    use super::{display_preserving_absolute, expand_leading_tilde, paths_equivalent};
+    use std::path::PathBuf;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "openmw_config_util_{name}_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
 
     #[test]
     fn test_expand_tilde_leaves_regular_path_unchanged() {
@@ -120,7 +173,7 @@ mod tests {
     #[test]
     fn test_expand_tilde_does_not_expand_named_user_syntax() {
         let value = "~alice/mods";
-        assert_eq!(expand_leading_tilde(value), std::path::PathBuf::from(value));
+        assert_eq!(expand_leading_tilde(value), PathBuf::from(value));
     }
 
     #[test]
@@ -130,5 +183,33 @@ mod tests {
         assert_eq!(expand_leading_tilde("~"), home);
         assert_eq!(expand_leading_tilde("~/mods"), home.join("mods"));
         assert_eq!(expand_leading_tilde("~\\mods"), home.join("mods"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_paths_equivalent_treats_symlinked_directories_as_same() {
+        let root = unique_temp_dir("symlink_equivalence");
+        let real_home = root.join("real_home");
+        let linked_home = root.join("linked_home");
+        let real_config = real_home.join(".config").join("openmw");
+        let linked_config = linked_home.join(".config").join("openmw");
+
+        std::fs::create_dir_all(&real_config).unwrap();
+        std::os::unix::fs::symlink(&real_home, &linked_home).unwrap();
+
+        assert!(paths_equivalent(&linked_config, &real_config));
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn test_display_preserving_absolute_leaves_absolute_paths_alone() {
+        let path = if cfg!(windows) {
+            PathBuf::from(r"C:\Users\Example\openmw.cfg")
+        } else {
+            PathBuf::from("/home/example/openmw.cfg")
+        };
+
+        assert_eq!(display_preserving_absolute(&path).unwrap(), path);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,14 @@
 //! an `openmw.cfg` file) and `OPENMW_CONFIG_DIR` (directory containing `openmw.cfg`) override root
 //! config discovery. Without those, [`OpenMWConfiguration::from_env`] tries an `openmw.cfg` adjacent
 //! to the running executable, then the platform global `OpenMW` config. User config is loaded only
-//! when referenced by the root config, usually through `config="?userconfig?"`.
+//! when referenced by the root config, usually through `config="?userconfig?"`. External tools that
+//! want this order plus a user-config fallback should use
+//! [`OpenMWConfiguration::from_env_or_user_config`].
 //!
 //! Path helpers intentionally distinguish the user config path (`?userconfig?`,
-//! [`try_default_config_path`]), the global config path ([`try_default_global_config_path`]), and
-//! the global data-token path (`?global?`, [`try_default_global_path`]). Those are not synonyms.
+//! [`try_default_config_path`]), the user config file ([`try_default_user_config_file`]), the global
+//! config path ([`try_default_global_config_path`]), and the global data-token path (`?global?`,
+//! [`try_default_global_path`]). Those are not synonyms.
 //!
 //! Serialization has two contracts. [`OpenMWConfiguration`]'s [`std::fmt::Display`] implementation
 //! and preservation save APIs keep directory settings in their original spelling for round-trips.
@@ -190,6 +193,27 @@ pub fn default_config_path() -> std::path::PathBuf {
     try_default_config_path().expect(NO_CONFIG_DIR)
 }
 
+/// Fallible variant of [`default_user_config_file`].
+///
+/// Resolves the default user `openmw.cfg` file, i.e. [`try_default_config_path`] plus
+/// `openmw.cfg`. This is the file behind the `?userconfig?` token, not `OpenMW`'s root startup
+/// config.
+///
+/// # Errors
+/// Returns [`ConfigError::PlatformPathUnavailable`] if no platform config directory can be discovered.
+pub fn try_default_user_config_file() -> Result<std::path::PathBuf, ConfigError> {
+    try_default_config_path().map(|path| path.join("openmw.cfg"))
+}
+
+/// Path to the default user `openmw.cfg` file.
+///
+/// # Panics
+/// Panics if the platform config directory cannot be determined (unsupported system).
+#[must_use]
+pub fn default_user_config_file() -> std::path::PathBuf {
+    try_default_user_config_file().expect(NO_CONFIG_DIR)
+}
+
 /// Fallible variant of [`default_userdata_path`].
 ///
 /// Resolution precedence:
@@ -296,6 +320,43 @@ pub fn try_default_root_config_path() -> Result<std::path::PathBuf, ConfigError>
     }
 
     Err(ConfigError::CannotFindRootConfig { local, global })
+}
+
+/// Find the default root `openmw.cfg`, falling back to the default user `openmw.cfg`.
+///
+/// This is intended for external tools that should honor package/global root configs when present,
+/// but should still work on installs that only have a user config. It does not change
+/// [`try_default_root_config_path`], which remains strict `OpenMW` startup/root discovery.
+///
+/// # Errors
+/// Returns [`ConfigError`] if platform paths cannot be resolved or no root/user `openmw.cfg` exists.
+pub fn try_default_root_or_user_config_path() -> Result<std::path::PathBuf, ConfigError> {
+    match try_default_root_config_path() {
+        Ok(path) => Ok(path),
+        Err(ConfigError::CannotFindRootConfig { local, global }) => {
+            let user = try_default_user_config_file()?;
+
+            if user.is_file() {
+                Ok(user)
+            } else {
+                Err(ConfigError::CannotFindAnyConfig {
+                    local,
+                    global,
+                    user,
+                })
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Path to the default root-or-user `openmw.cfg` discovered for external tools.
+///
+/// # Panics
+/// Panics if no root or user config can be found.
+#[must_use]
+pub fn default_root_or_user_config_path() -> std::path::PathBuf {
+    try_default_root_or_user_config_path().expect("FAILURE: COULD NOT FIND ROOT OR USER CONFIG")
 }
 
 /// Path to the default root `openmw.cfg` discovered with `OpenMW` startup semantics.

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -417,10 +417,29 @@ impl UserData for LuaOpenMWConfiguration {
 pub fn create_lua_module(lua: &Lua) -> mlua::Result<Table> {
     let exports = lua.create_table()?;
 
+    register_config_loaders(lua, &exports)?;
+    register_default_path_helpers(lua, &exports)?;
+    register_try_path_helpers(lua, &exports)?;
+
+    exports.set("version", env!("CARGO_PKG_VERSION"))?;
+
+    Ok(exports)
+}
+
+fn register_config_loaders(lua: &Lua, exports: &Table) -> mlua::Result<()> {
     exports.set(
         "fromEnv",
         lua.create_function(|_, ()| {
             OpenMWConfiguration::from_env()
+                .map(LuaOpenMWConfiguration::new)
+                .map_err(lua_err)
+        })?,
+    )?;
+
+    exports.set(
+        "fromEnvOrUserConfig",
+        lua.create_function(|_, ()| {
+            OpenMWConfiguration::from_env_or_user_config()
                 .map(LuaOpenMWConfiguration::new)
                 .map_err(lua_err)
         })?,
@@ -453,9 +472,18 @@ pub fn create_lua_module(lua: &Lua) -> mlua::Result<Table> {
         })?,
     )?;
 
+    Ok(())
+}
+
+fn register_default_path_helpers(lua: &Lua, exports: &Table) -> mlua::Result<()> {
     exports.set(
         "defaultConfigPath",
         lua.create_function(|_, ()| Ok(crate::default_config_path().display().to_string()))?,
+    )?;
+
+    exports.set(
+        "defaultUserConfigFile",
+        lua.create_function(|_, ()| Ok(crate::default_user_config_file().display().to_string()))?,
     )?;
 
     exports.set(
@@ -478,12 +506,34 @@ pub fn create_lua_module(lua: &Lua) -> mlua::Result<Table> {
         lua.create_function(|_, ()| Ok(crate::default_global_path().display().to_string()))?,
     )?;
 
+    Ok(())
+}
+
+fn register_try_path_helpers(lua: &Lua, exports: &Table) -> mlua::Result<()> {
     exports.set(
         "tryDefaultConfigPath",
         lua.create_function(|_, ()| match crate::try_default_config_path() {
             Ok(path) => Ok((Some(path.display().to_string()), Option::<String>::None)),
             Err(error) => Ok((Option::<String>::None, Some(error.to_string()))),
         })?,
+    )?;
+
+    exports.set(
+        "tryDefaultUserConfigFile",
+        lua.create_function(|_, ()| match crate::try_default_user_config_file() {
+            Ok(path) => Ok((Some(path.display().to_string()), Option::<String>::None)),
+            Err(error) => Ok((Option::<String>::None, Some(error.to_string()))),
+        })?,
+    )?;
+
+    exports.set(
+        "tryDefaultRootOrUserConfigPath",
+        lua.create_function(
+            |_, ()| match crate::try_default_root_or_user_config_path() {
+                Ok(path) => Ok((Some(path.display().to_string()), Option::<String>::None)),
+                Err(error) => Ok((Option::<String>::None, Some(error.to_string()))),
+            },
+        )?,
     )?;
 
     exports.set(
@@ -510,7 +560,5 @@ pub fn create_lua_module(lua: &Lua) -> mlua::Result<Table> {
         })?,
     )?;
 
-    exports.set("version", env!("CARGO_PKG_VERSION"))?;
-
-    Ok(exports)
+    Ok(())
 }

--- a/tests/integration_lua_bindings.rs
+++ b/tests/integration_lua_bindings.rs
@@ -18,6 +18,18 @@ mod lua_tests {
         base
     }
 
+    unsafe fn clear_config_env() {
+        // SAFETY: callers hold ENV_LOCK, so process-global environment mutation is serialized.
+        unsafe {
+            std::env::remove_var("OPENMW_CONFIG");
+            std::env::remove_var("OPENMW_CONFIG_DIR");
+            std::env::remove_var("OPENMW_GLOBAL_CONFIG_PATH");
+            std::env::remove_var("OPENMW_CONFIG_USING_FLATPAK");
+            std::env::remove_var("OPENMW_FLATPAK_ID");
+            std::env::remove_var("FLATPAK_ID");
+        }
+    }
+
     const READ_SURFACE_SCRIPT: &str = r##"
             local cfg = openmwConfig.new(rootPath)
 
@@ -108,9 +120,11 @@ mod lua_tests {
             assert(type(openmwConfig.version) == "string")
 
             assert(type(openmwConfig.defaultConfigPath()) == "string")
+            assert(type(openmwConfig.defaultUserConfigFile()) == "string")
             assert(type(openmwConfig.defaultUserDataPath()) == "string")
             assert(type(openmwConfig.defaultDataLocalPath()) == "string")
             assert(type(openmwConfig.defaultLocalPath()) == "string")
+            assert(type(openmwConfig.fromEnvOrUserConfig) == "function")
 
             if openmwConfig.tryDefaultGlobalPath then
               local globalPath, globalErr = openmwConfig.tryDefaultGlobalPath()
@@ -119,6 +133,12 @@ mod lua_tests {
 
             local cfgPath, cfgErr = openmwConfig.tryDefaultConfigPath()
             assert((cfgPath ~= nil and cfgErr == nil) or (cfgPath == nil and cfgErr ~= nil))
+
+            local userCfg, userCfgErr = openmwConfig.tryDefaultUserConfigFile()
+            assert((userCfg ~= nil and userCfgErr == nil) or (userCfg == nil and userCfgErr ~= nil))
+
+            local rootOrUser, rootOrUserErr = openmwConfig.tryDefaultRootOrUserConfigPath()
+            assert((rootOrUser ~= nil and rootOrUserErr == nil) or (rootOrUser == nil and rootOrUserErr ~= nil))
 
             local dataPath, dataErr = openmwConfig.tryDefaultUserDataPath()
             assert((dataPath ~= nil and dataErr == nil) or (dataPath == nil and dataErr ~= nil))
@@ -143,6 +163,7 @@ mod lua_tests {
 
         // SAFETY: guarded by a global mutex so no concurrent env mutation occurs in tests.
         unsafe {
+            clear_config_env();
             std::env::set_var("OPENMW_CONFIG", &root_cfg);
         }
 
@@ -161,7 +182,48 @@ mod lua_tests {
 
         // SAFETY: guarded by a global mutex so no concurrent env mutation occurs in tests.
         unsafe {
-            std::env::remove_var("OPENMW_CONFIG");
+            clear_config_env();
+        }
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_lua_from_env_or_user_config_fallback() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let empty_global = temp_dir("lua_empty_global");
+        let xdg_config_home = temp_dir("lua_xdg_config_home");
+        let user_config_dir = xdg_config_home.join("openmw");
+        write_cfg(&user_config_dir, "content=LuaUserOnly.esm\n");
+        let expected_cfg = user_config_dir.join("openmw.cfg");
+
+        // SAFETY: guarded by a global mutex so no concurrent env mutation occurs in tests.
+        unsafe {
+            clear_config_env();
+            std::env::set_var("OPENMW_GLOBAL_CONFIG_PATH", &empty_global);
+            std::env::set_var("XDG_CONFIG_HOME", &xdg_config_home);
+        }
+
+        let lua = Lua::new();
+        let module = create_lua_module(&lua).unwrap();
+        lua.globals().set("openmwConfig", module).unwrap();
+        lua.globals()
+            .set("expectedCfg", expected_cfg.display().to_string())
+            .unwrap();
+
+        lua.load(
+            r#"
+            local cfg = openmwConfig.fromEnvOrUserConfig()
+            assert(cfg:rootConfigFile() == expectedCfg)
+            assert(cfg:hasContentFile("LuaUserOnly.esm"))
+        "#,
+        )
+        .exec()
+        .unwrap();
+
+        // SAFETY: guarded by a global mutex so no concurrent env mutation occurs in tests.
+        unsafe {
+            clear_config_env();
+            std::env::remove_var("XDG_CONFIG_HOME");
         }
     }
 

--- a/tests/integration_lua_bindings.rs
+++ b/tests/integration_lua_bindings.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "lua")]
 mod lua_tests {
     use mlua::Lua;
-    use openmw_config::create_lua_module;
+    use openmw_config::{create_lua_module, try_default_config_path};
     use std::{path::Path, sync::Mutex};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -27,6 +27,17 @@ mod lua_tests {
             std::env::remove_var("OPENMW_CONFIG_USING_FLATPAK");
             std::env::remove_var("OPENMW_FLATPAK_ID");
             std::env::remove_var("FLATPAK_ID");
+        }
+    }
+
+    fn restore_env_var(key: &str, value: Option<std::ffi::OsString>) {
+        // SAFETY: callers hold ENV_LOCK, so process-global environment mutation is serialized.
+        unsafe {
+            if let Some(value) = value {
+                std::env::set_var(key, value);
+            } else {
+                std::env::remove_var(key);
+            }
         }
     }
 
@@ -191,17 +202,22 @@ mod lua_tests {
     fn test_lua_from_env_or_user_config_fallback() {
         let _guard = ENV_LOCK.lock().unwrap();
         let empty_global = temp_dir("lua_empty_global");
-        let xdg_config_home = temp_dir("lua_xdg_config_home");
-        let user_config_dir = xdg_config_home.join("openmw");
-        write_cfg(&user_config_dir, "content=LuaUserOnly.esm\n");
-        let expected_cfg = user_config_dir.join("openmw.cfg");
+        let test_home = temp_dir("lua_home");
+        let test_xdg_config_home = temp_dir("lua_xdg_config_home");
+        let old_home = std::env::var_os("HOME");
+        let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
 
         // SAFETY: guarded by a global mutex so no concurrent env mutation occurs in tests.
         unsafe {
             clear_config_env();
             std::env::set_var("OPENMW_GLOBAL_CONFIG_PATH", &empty_global);
-            std::env::set_var("XDG_CONFIG_HOME", &xdg_config_home);
+            std::env::set_var("HOME", &test_home);
+            std::env::set_var("XDG_CONFIG_HOME", &test_xdg_config_home);
         }
+
+        let user_config_dir = try_default_config_path().unwrap();
+        write_cfg(&user_config_dir, "content=LuaUserOnly.esm\n");
+        let expected_cfg = user_config_dir.join("openmw.cfg");
 
         let lua = Lua::new();
         let module = create_lua_module(&lua).unwrap();
@@ -210,21 +226,24 @@ mod lua_tests {
             .set("expectedCfg", expected_cfg.display().to_string())
             .unwrap();
 
-        lua.load(
-            r#"
+        let lua_result = lua
+            .load(
+                r#"
             local cfg = openmwConfig.fromEnvOrUserConfig()
             assert(cfg:rootConfigFile() == expectedCfg)
             assert(cfg:hasContentFile("LuaUserOnly.esm"))
         "#,
-        )
-        .exec()
-        .unwrap();
+            )
+            .exec();
 
         // SAFETY: guarded by a global mutex so no concurrent env mutation occurs in tests.
         unsafe {
             clear_config_env();
-            std::env::remove_var("XDG_CONFIG_HOME");
         }
+        restore_env_var("HOME", old_home);
+        restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
+
+        lua_result.unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Cleans up config resolution to allow a fallback API so that you can use OpenMW's strict resolution *AND* fall back to the default configuration path, instead of only using the strict resolution functions.

Also cleans up directory handling for Linux distros such as Bazzite which symlink the homedir. This could also be symptomatic of advanced user fuckery, so, it needs dealt with internally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration discovery now supports fallback to default user config when external root config is unavailable
  * Added new Lua constructors and helpers for flexible config path resolution

* **Bug Fixes**
  * Improved path comparison to correctly handle symbolic links and equivalent paths
  * Enhanced absolute path representation preservation

* **Documentation**
  * Updated documentation with new external tools startup path configuration details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->